### PR TITLE
chore: fix for entrypoint.sh

### DIFF
--- a/ubuntu-dind/entrypoint.sh
+++ b/ubuntu-dind/entrypoint.sh
@@ -1,41 +1,23 @@
 #!/bin/bash
 source /opt/bash-utils/logger.sh
 
-DOTENV_FILE=/actions-runner/.env
-
-configure_runner() {
-    cd /actions-runner || exit
-
-    INFO "Allowing runner to run as root..."
-    export RUNNER_ALLOW_RUNASROOT="1"
-
-    DATA_DIR="/actions-runner/data/$HOSTNAME"
-
-    if [ -d "$DATA_DIR" ]; then
-        INFO "Runner already exists, copying configuration files..."
-        cp "$DATA_DIR/.credentials" "$DATA_DIR/.runner" "$DATA_DIR/.credentials_rsaparams" /actions-runner/
+load_env_variables() {
+    DOTENV_FILE=/actions-runner/.env
+    INFO "Loading environment variables from ${DOTENV_FILE} file..."
+    if [ -f ${DOTENV_FILE} ]; then
+        while IFS='=' read -r key value; do
+            # Skip comments and empty lines
+            if [[ ! $key =~ ^# ]] && [[ -n $key ]]; then
+                export "$key"="$value"
+            fi
+        done < ${DOTENV_FILE}
     else
-        INFO "Creating runner data directory..."
-        mkdir -p "$DATA_DIR"
-
-        INFO "Runner does not exist, configuring..."
-        ./config.sh \
-            --url ${RUNNER_GITHUB_URL}/${RUNNER_ORG} \
-            --token ${RUNNER_REG_TOKEN} \
-            --name ${HOSTNAME} \
-            --runnergroup ${RUNNER_GROUP} \
-            --labels ${RUNNER_LABELS} \
-            --unattended
-
-        INFO "Backing up the configuration files..."
-        cp /actions-runner/.credentials /actions-runner/.credentials_rsaparams /actions-runner/.runner "$DATA_DIR"
+        INFO "${DOTENV_FILE} file not found!"
+        exit 1
     fi
 }
 
-start_runner() {
-    INFO "Starting the runner..."
-    ./run.sh --once
-}
+load_env_variables
 
-configure_runner
-start_runner
+start-docker.sh
+start-runner.sh


### PR DESCRIPTION
This pull request includes significant changes to the `ubuntu-dind/entrypoint.sh` script, focusing on improving the loading of environment variables and simplifying the runner configuration process. The most important changes include the addition of a function to load environment variables from a `.env` file and the removal of the inline runner configuration and start logic.

Improvements to environment variable loading and runner configuration:

* Added `load_env_variables` function to handle loading environment variables from the `.env` file, including logic to skip comments and empty lines.
* Removed the inline runner configuration logic, simplifying the script and delegating the configuration to external scripts.
* Replaced the inline runner start logic with calls to `start-docker.sh` and `start-runner.sh` scripts.